### PR TITLE
try to make compatible with node-mysql

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ class SQLStatement {
   constructor(strings, values) {
     this.strings = strings
     this.values = values
+    this.calculateSql()
   }
 
   /** Returns the SQL Statement for node-postgres */
@@ -16,9 +17,9 @@ class SQLStatement {
     return this.strings.reduce((prev, curr, i) => prev + '$' + i + curr)
   }
 
-  /** Returns the SQL Statement for mysql */
-  get sql() {
-    return this.strings.join('?')
+  /** Calculate the SQL Statement for mysql */
+  calculateSql() {
+    this.sql = this.strings.join('?')
   }
 
   /**
@@ -33,6 +34,7 @@ class SQLStatement {
     } else {
       this.strings[this.strings.length - 1] += statement
     }
+    this.calculateSql()
     return this
   }
 


### PR DESCRIPTION
version 2.x use class 'get sql' to construct the sql string, this is not working with node-mysql.

node-mysql use for(prop in sql), so the 'get sql' will not be called.

copy from https://github.com/felixfbecker/node-sql-template-strings/issues/6