### PR TITLE
Handle case when SQLStatement passed as parameter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,36 @@ class SQLStatement {
    * @param {any[]} values
    */
   constructor(strings, values) {
-    this.strings = strings
-    this.values = values
+    if (values.length === 0) {
+      this.strings = strings
+      this.values = values
+    } else {
+      this.strings = []
+      this.values = []
+      let prevOpened = false
+      const valuesLength = values.length
+      for (let i = 0; i < valuesLength; i++) {
+        if (prevOpened) {
+          this.strings[this.strings.length - 1] += strings[i]
+          prevOpened = false
+        } else {
+          this.strings.push(strings[i])
+        }
+        const value = values[i]
+        if (value instanceof SQLStatement) {
+          this.append(value)
+          prevOpened = true
+        } else {
+          this.values.push(value)
+        }
+      }
+      if (prevOpened) {
+        this.strings[this.strings.length - 1] += strings[valuesLength]
+        prevOpened = false
+      } else {
+        this.strings.push(strings[valuesLength])
+      }
+    }
   }
 
   /** Returns the SQL Statement for Sequelize */

--- a/test/unit.js
+++ b/test/unit.js
@@ -114,6 +114,15 @@ describe('SQL', () => {
       assert.equal(statement.sql, 'SELECT * FROM table')
       assert.deepEqual(statement.values, [])
     })
+
+    it('should merge 2 consequence SQLStatement parameters', () => {
+      const s1 = SQL`SELECT `
+      const s2 = SQL`* FROM`
+      const s3 = SQL` table_name WHERE key=${'value'}`
+      const s4 = SQL`${s1}${s2}${s3}`
+      assert.equal(s4.sql, 'SELECT * FROM table_name WHERE key=?')
+      assert.deepEqual(s4.values, ['value'])
+    })
   })
 
   describe('setName()', () => {


### PR DESCRIPTION
This PR introduces ability to pass SQLStatement as parameter to other SQLStatement cosntructor.
It could be used as more straighforward alternative to `.append` method.

See #30.