### PR TITLE
feat: Add 'concat' method as immutable alternative to 'append'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,24 @@ export class SQLStatement {
   append(statement: SQLStatement | string | number): this
 
   /**
+   * Concatenates a string or another statement and returns a new instance of SQLStatement
+   * (Immutable version of append)
+   *
+   * ```ts
+   * query.concat(SQL`AND genre = ${genre}`).concat(' ORDER BY rating')
+   * query.text   // => 'SELECT author FROM books WHERE name = $1 AND author = $2 AND genre = $3 ORDER BY rating'
+   * query.sql    // => 'SELECT author FROM books WHERE name = ? AND author = ? AND genre = ? ORDER BY rating'
+   * query.values // => ['harry potter', 'J. K. Rowling', 'Fantasy'] ORDER BY rating`
+   *
+   * const baseQuery = SQL`SELECT * FROM books`;
+   * baseQuery.concat(SQL` WHERE name = ${params.name}`).text // => 'SELECT * FROM books WHERE name = $1'
+   * basequery.concat(SQL` WHERE author = ${params.author}`).text // => 'SELECT * FROM books WHERE author = $1'
+   * ```
+   */
+  concat(statement: SQLStatement | string | number): SQLStatement
+
+
+  /**
    * Sets the name property of this statement for prepared statements in postgres
    *
    * ```ts

--- a/index.js
+++ b/index.js
@@ -36,6 +36,30 @@ class SQLStatement {
   }
 
   /**
+   * @param {SQLStatement|string} statement
+   * @returns {SQLStatement}
+   */
+  concat(statement) {
+    const sqlStatement = new SQLStatement(this.strings.slice())
+
+    if(this.bind) {
+      sqlStatement.bind = this.bind.slice();
+      delete sqlStatement.values;
+    } else {
+      sqlStatement.values = this.values.slice();
+    }
+
+    if (statement instanceof SQLStatement) {
+      sqlStatement.strings[sqlStatement.strings.length - 1] += statement.strings[0]
+      sqlStatement.strings.push.apply(sqlStatement.strings, statement.strings.slice(1))
+      ;(sqlStatement.values || sqlStatement.bind).push.apply(sqlStatement.values, statement.values)
+    } else {
+      sqlStatement.strings[sqlStatement.strings.length - 1] += statement
+    }
+    return sqlStatement
+  }
+
+  /**
    * Use a prepared statement with Sequelize.
    * Makes `query` return a query with `$n` syntax instead of `?`  and switches the `values` key name to `bind`
    * @param {boolean} [value=true] value If omitted, defaults to `true`

--- a/test/unit.js
+++ b/test/unit.js
@@ -75,6 +75,58 @@ describe('SQL', () => {
     })
   })
 
+  describe('concat()', () => {
+    it('should return new SQLStatement instance', () => {
+      const query = SQL`SELECT * FROM table`
+      assert.notStrictEqual(query, query.concat('whatever'))
+      assert(query instanceof SQL.SQLStatement)
+    })
+
+    it('should concat a second SQLStatement', () => {
+      const value1 = 1234
+      const value2 = 5678
+      const query = SQL`SELECT * FROM table WHERE column = ${value1}`.concat(SQL` AND other_column = ${value2}`)
+      assert.equal(query.sql, 'SELECT * FROM table WHERE column = ? AND other_column = ?')
+      assert.equal(query.text, 'SELECT * FROM table WHERE column = $1 AND other_column = $2')
+      assert.deepEqual(query.values, [value1, value2])
+    })
+
+    it('should be immutable', () => {
+      const value1 = 1234
+      const value2 = 5678
+      const value3 = 9876
+      const baseQuery = SQL`SELECT * FROM table WHERE column = ${value1}`;
+      
+      const query1 = baseQuery.concat(SQL` AND other_column = ${value2}`);
+      const query2 = baseQuery.concat(SQL` AND other_column = ${value3}`);
+      assert.equal(query1.sql, 'SELECT * FROM table WHERE column = ? AND other_column = ?')
+      assert.equal(query1.text, 'SELECT * FROM table WHERE column = $1 AND other_column = $2')
+      assert.deepEqual(query1.values, [value1, value2])
+      assert.equal(query2.sql, 'SELECT * FROM table WHERE column = ? AND other_column = ?')
+      assert.equal(query2.text, 'SELECT * FROM table WHERE column = $1 AND other_column = $2')
+      assert.deepEqual(query2.values, [value1, value3])
+    })
+
+    it('should concat a string', () => {
+      const value = 1234
+      const query = SQL`SELECT * FROM table WHERE column = ${value}`.concat(' ORDER BY other_column')
+      assert.equal(query.sql, 'SELECT * FROM table WHERE column = ? ORDER BY other_column')
+      assert.equal(query.text, 'SELECT * FROM table WHERE column = $1 ORDER BY other_column')
+      assert.deepEqual(query.values, [value])
+    })
+
+    it('should work with a bound statement', () => {
+      const value = 1234
+      const statement = SQL`SELECT * FROM table WHERE column = ${value}`.useBind(true).concat(' ORDER BY other_column')
+      assert.equal(statement.sql, 'SELECT * FROM table WHERE column = ? ORDER BY other_column')
+      assert.equal(statement.text, 'SELECT * FROM table WHERE column = $1 ORDER BY other_column')
+      assert.strictEqual(statement.query, 'SELECT * FROM table WHERE column = $1 ORDER BY other_column')
+      assert.strictEqual(statement.values, undefined)
+      assert.strictEqual('values' in statement, false)
+      assert.deepStrictEqual(statement.bind, [1234])
+    })
+  })
+
   describe('setName()', () => {
     it('should set the name and return this', () => {
       assert.equal(SQL`SELECT * FROM table`.setName('my_query').name, 'my_query')


### PR DESCRIPTION
Useful for reusing a base query with multiple different appended statements:

Example:
```javascript
const baseQuery = SQL`SELECT * FROM books`;

app.get("/", (req, res) => {
  const query = baseQuery.concat(SQL` WHERE id = ${req.params.id}`);
  // Some response
});
```

References #71