### PR TITLE
Add SQL.raw, allow queries to be nested

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -40,6 +40,16 @@ describe('SQL', () => {
     throw new assert.AssertionError({ message: 'expected enumerable property "sql"' })
   })
 
+  it('should work with contained queries', () => {
+    const cols = SQL.raw('*')
+    const whereClause = SQL`column1 = ${1}`
+    const query = SQL`SELECT ${cols} FROM table WHERE ${whereClause} AND column2 = ${2}`
+    assert.equal(query.sql, 'SELECT * FROM table WHERE column1 = ? AND column2 = ?')
+    assert.equal(query.query, 'SELECT * FROM table WHERE column1 = ? AND column2 = ?')
+    assert.equal(query.text, 'SELECT * FROM table WHERE column1 = $1 AND column2 = $2')
+    assert.deepEqual(query.values, [1, 2])
+  })
+
   describe('append()', () => {
     it('should return this', () => {
       const query = SQL`SELECT * FROM table`


### PR DESCRIPTION
For example:

```js
const columns = SQL.raw("foo, bar")
const whereClause = SQL`foo = ${someValue}`
const query = SQL`SELECT ${columns} FROM table WHERE ${whereClause}`
```

TODO:
- [] TypeScript typings
- [] Import more extensive unit tests
- [] Introduce `SQL.join` helper:

```js
const fields = {
    foo: 'hello',
    bar: 'world',
}
const updateClause = SQL.join(', ', Object.entries(fields).map(([col, val]) => {
    return SQL`${SQL.raw(escapeLiteral(col))} = ${val}`
})
const query = SQL`UPDATE table SET ${updateClause} WHERE ...`
```