### PR TITLE
feat: Ignore empty and undefined append args

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class SQLStatement {
   }
 
   /**
-   * @param {SQLStatement|string} statement
+   * @param {SQLStatement|string} statement. Undefined or empty strings are ignored.
    * @returns {this}
    */
   append(statement) {
@@ -30,7 +30,7 @@ class SQLStatement {
       this.strings.push.apply(this.strings, statement.strings.slice(1))
       const list = this.values || this.bind
       list.push.apply(list, statement.values)
-    } else {
+    } else if (statement) {
       this.strings[this.strings.length - 1] += statement
     }
     return this

--- a/test/unit.js
+++ b/test/unit.js
@@ -73,6 +73,30 @@ describe('SQL', () => {
       assert.strictEqual('values' in statement, false)
       assert.deepStrictEqual(statement.bind, [1234])
     })
+
+    it('should ignore undefined arguments', () => {
+      const value = 1234
+      const query = SQL`SELECT * FROM table WHERE column = ${value}`.append(undefined)
+      assert.equal(query.sql, 'SELECT * FROM table WHERE column = ?')
+      assert.equal(query.text, 'SELECT * FROM table WHERE column = $1')
+      assert.deepEqual(query.values, [value])
+    })
+
+    it('should ignore empty arguments', () => {
+      const value = 1234
+      const query = SQL`SELECT * FROM table WHERE column = ${value}`.append()
+      assert.equal(query.sql, 'SELECT * FROM table WHERE column = ?')
+      assert.equal(query.text, 'SELECT * FROM table WHERE column = $1')
+      assert.deepEqual(query.values, [value])
+    })
+
+    it('should ignore empty string arguments', () => {
+      const value = 1234
+      const query = SQL`SELECT * FROM table WHERE column = ${value}`.append('')
+      assert.equal(query.sql, 'SELECT * FROM table WHERE column = ?')
+      assert.equal(query.text, 'SELECT * FROM table WHERE column = $1')
+      assert.deepEqual(query.values, [value])
+    })
   })
 
   describe('setName()', () => {


### PR DESCRIPTION
This makes conditional chaining even easier:

```
SQL`SELECT * FROM table`
  .append(where(...))
  .append(orderBy(...))
```